### PR TITLE
fix: improvements for PQ tournaments page in new meta, add `nameTempl…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "4.2.0",
+  "version": "4.2.1",
   "type": "module",
   "scripts": {
     "dev": "bunx --bun vite",

--- a/frontend/src/api/tournament-groups/useGetTournamentGroups.ts
+++ b/frontend/src/api/tournament-groups/useGetTournamentGroups.ts
@@ -8,12 +8,22 @@ export type GetTournamentGroupsRequest = {
   meta?: number;
   visible?: boolean;
   includeStats?: boolean;
+  nameTemplate?: string;
   sort?: 'name' | 'position' | 'created_at';
   order?: 'asc' | 'desc';
+  pageSize?: number;
 };
 
 export const useGetTournamentGroups = (props: GetTournamentGroupsRequest = {}) => {
-  const { meta, visible, includeStats, sort = 'position', order = 'asc' } = props;
+  const {
+    meta,
+    visible,
+    includeStats,
+    nameTemplate,
+    sort = 'position',
+    order = 'asc',
+    pageSize = PAGE_SIZE,
+  } = props;
 
   // Create a stable query key based on all filter parameters
   const qk = [
@@ -22,6 +32,7 @@ export const useGetTournamentGroups = (props: GetTournamentGroupsRequest = {}) =
       meta,
       visible,
       includeStats,
+      nameTemplate,
       sort,
       order,
     },
@@ -35,9 +46,10 @@ export const useGetTournamentGroups = (props: GetTournamentGroupsRequest = {}) =
           meta: meta?.toString(),
           visible: visible?.toString(),
           includeStats: includeStats?.toString(),
+          nameTemplate,
           sort,
           order,
-          limit: PAGE_SIZE.toString(),
+          limit: pageSize.toString(),
           offset: pageParam.toString(),
         },
       });

--- a/frontend/src/components/app/admin/TournamentGroupsPage.tsx
+++ b/frontend/src/components/app/admin/TournamentGroupsPage.tsx
@@ -32,11 +32,10 @@ export function TournamentGroupsPage() {
   const [detailDialogOpen, setDetailDialogOpen] = useState(false);
   const [selectedGroup, setSelectedGroup] = useState<TournamentGroupWithMeta | null>(null);
 
-  console.log('Here.');
-
   const params = useMemo(
     () => ({
       meta: selectedMetaId || undefined,
+      pageSize: 200,
     }),
     [selectedMetaId],
   );

--- a/frontend/src/components/app/tournaments/pages/TournamentsPlanetaryQualifiers/TournamentsPlanetaryQualifiers.tsx
+++ b/frontend/src/components/app/tournaments/pages/TournamentsPlanetaryQualifiers/TournamentsPlanetaryQualifiers.tsx
@@ -19,6 +19,7 @@ const TournamentsPlanetaryQualifiers: React.FC<TournamentsPlanetaryQualifiersPro
       meta: metaId,
       visible: false,
       includeStats: true,
+      nameTemplate: 'PQ Week%',
     }),
     [metaId],
   );

--- a/frontend/src/components/app/tournaments/pages/TournamentsPlanetaryQualifiers/hooks/useProcessedTournamentGroups.ts
+++ b/frontend/src/components/app/tournaments/pages/TournamentsPlanetaryQualifiers/hooks/useProcessedTournamentGroups.ts
@@ -42,7 +42,11 @@ export const useProcessedTournamentGroups = (
       const isMostRecent = index === mostRecentGroupIndex;
 
       // Get the week number from the group or generate one
-      const weekNumber = index + 1; // Assuming sequential weeks
+      let weekNumber = index + 1; // just in case
+      const weekNumberMatch = group.group.name.match(/PQ Week (\d+)/);
+      if (weekNumberMatch && weekNumberMatch[1]) {
+        weekNumber = parseInt(weekNumberMatch[1], 10);
+      }
 
       // Generate a description for the group
       // This could be based on dates, tournament names, etc.


### PR DESCRIPTION
fix: improvements for PQ tournaments page in new meta, add `nameTemplate` prop to GET tournament-groups, v4.2.1